### PR TITLE
fixed type of mul to work with DiagOp

### DIFF
--- a/src/NFFTNormalOpBasisFunc.jl
+++ b/src/NFFTNormalOpBasisFunc.jl
@@ -83,7 +83,7 @@ function NFFTNormalOpBasisFunc(
 end
 
 
-function LinearAlgebra.mul!(x::Vector{T}, S::NFFTNormalOpBasisFunc, b, α, β) where {T}
+function LinearAlgebra.mul!(x::AbstractVector{T}, S::NFFTNormalOpBasisFunc, b, α, β) where {T}
     idx = CartesianIndices(S.shape)
     idxos = CartesianIndices(2 .* S.shape)
     Ncoils = length(S.cmaps)


### PR DESCRIPTION
Changed the type requirements of x in mul! so it works with the DiagOp of MRIOperatos. 