### PR TITLE
Changedata2vector

### DIFF
--- a/src/BackProjection.jl
+++ b/src/BackProjection.jl
@@ -19,7 +19,7 @@ Calculate backprojection
 # Notes
 - The type of the elements of the trajectory define if a gridded backprojection (eltype(trj[1]) or eltype(trj) <: Int) or a non-uniform (else) is performed.
 """
-function calculateBackProjection(data::AbstractVector{<:AbstractMatrix{cT}}, trj::AbstractVector{<:AbstractMatrix{T}}, img_shape::NTuple{N,Int}; U=I(length(data)), density_compensation=:none, verbose=false) where {T, cT <: Complex{T},N}
+function calculateBackProjection(data::AbstractVector{<:AbstractArray{cT}}, trj::AbstractVector{<:AbstractMatrix{T}}, img_shape::NTuple{N,Int}; U=I(length(data)), density_compensation=:none, verbose=false) where {T <: Real, cT <: Complex{T},N}
     Ncoef = size(U,2)
 
     trj_v = reduce(hcat, trj)
@@ -34,7 +34,7 @@ function calculateBackProjection(data::AbstractVector{<:AbstractMatrix{cT}}, trj
     img_idx = CartesianIndices(img_shape)
     verbose && println("calculating backprojection..."); flush(stdout)
     for icoef ∈ axes(U, 2)
-        t = @elapsed for icoil = 1:Ncoil
+        t = @elapsed for icoil ∈ axes(data[1], 2)
             @simd for it in axes(data,1)
                 idx1 = sum(trj_l[1:it-1]) + 1
                 idx2 = sum(trj_l[1:it])
@@ -49,7 +49,7 @@ function calculateBackProjection(data::AbstractVector{<:AbstractMatrix{cT}}, trj
     return xbp
 end
 
-function calculateBackProjection(data::AbstractVector{<:AbstractMatrix{cT}}, trj::AbstractVector{<:AbstractMatrix{T}}, cmaps::AbstractVector{<:AbstractArray{cT,N}}; U=I(length(data)), density_compensation=:none, verbose=false) where {T, cT <: Complex{T}, N}
+function calculateBackProjection(data::AbstractVector{<:AbstractMatrix{cT}}, trj::AbstractVector{<:AbstractMatrix{T}}, cmaps::AbstractVector{<:AbstractArray{cT,N}}; U=I(length(data)), density_compensation=:none, verbose=false) where {T <: Real, cT <: Complex{T}, N}
     test_dimension(data, trj, U, cmaps)
 
     trj_v = reduce(hcat, trj)
@@ -82,7 +82,7 @@ function calculateBackProjection(data::AbstractVector{<:AbstractMatrix{cT}}, trj
     return xbp
 end
 
-function calculateBackProjection(data::AbstractMatrix{cT}, trj::AbstractMatrix{T}, cmaps_img_shape; U=I(1), density_compensation=:none, verbose=false) where {T, cT <: Complex{T}}
+function calculateBackProjection(data::AbstractArray{cT}, trj::AbstractMatrix{T}, cmaps_img_shape; U=I(1), density_compensation=:none, verbose=false) where {T <: Real, cT <: Complex{T}}
     return calculateBackProjection([data], [trj], cmaps_img_shape; U, density_compensation, verbose)
 end
 

--- a/src/BackProjection.jl
+++ b/src/BackProjection.jl
@@ -83,7 +83,7 @@ end
 
 
 """
-    calculateBackProjection_gridded(data, trj, U, cmaps)
+    calculateBackProjection(data, trj, U, cmaps)
 
 Calculate gridded backprojection
 
@@ -97,7 +97,7 @@ Calculate gridded backprojection
 In case of repeated sampling (Nrep > 1), a joint basis reconstruction is required.
 Therefore, the basis needs to have a temporal dimension of Nt⋅Nrep with Nt as time dimension defined by the trajectory.
 """
-function calculateBackProjection_gridded(data, trj, U, cmaps)
+function calculateBackProjection(data::AbstractVector{<:AbstractArray}, trj::AbstractVector{<:AbstractMatrix{<:Integer}}, cmaps; U=I(length(data)))
     Ncoeff = size(U, 2)
     img_shape = size(cmaps[1])
     img_idx = CartesianIndices(img_shape)

--- a/src/BackProjection.jl
+++ b/src/BackProjection.jl
@@ -133,16 +133,16 @@ end
 #############################################################################
 
 function applyDensityCompensation!(data, trj; density_compensation=:radial_3D)
-    data_temp = reshape(data,:,length(trj))
-    for it in axes(data_temp, 2)
+    data = reshape(data,:,length(trj))
+    for it in axes(data, 2)
         if density_compensation == :radial_3D
-            data_temp[:,it] .*= transpose(sum(abs2, trj[it], dims=1))
+            data[:, it] .*= transpose(sum(abs2, trj[it], dims=1))
         elseif density_compensation == :radial_2D
-            data_temp[:,it] .*= transpose(sqrt.(sum(abs2, trj[it], dims=1)))
+            data[:, it] .*= transpose(sqrt.(sum(abs2, trj[it], dims=1)))
         elseif density_compensation == :none
             # do nothing here
         elseif isa(density_compensation, AbstractVector{<:AbstractVector})
-            data_temp[:,it] .*= density_compensation[it]
+            data[:, it] .*= density_compensation[it]
         else
             error("`density_compensation` can only be `:radial_3D`, `:radial_2D`, `:none`, or of type  `AbstractVector{<:AbstractVector}`")
         end

--- a/src/BackProjection.jl
+++ b/src/BackProjection.jl
@@ -14,65 +14,52 @@ Calculate backprojection
 - `cmaps::::AbstractVector{<:AbstractArray{T}}`: Coil sensitivities
 
 """
-function calculateBackProjection(data::AbstractArray{T}, trj, img_shape::NTuple{N,Int}; U = N==3 ? I(size(data,2)) : I(1), density_compensation=:none, verbose=false) where {N,T}
-    if typeof(trj) <: AbstractMatrix
-        trj = [trj]
-    end
-
-    if ndims(data) == 2
-        data = reshape(data, size(data, 1), 1, size(data, 2))
-    end
-    Ncoils = size(data, 3)
+function calculateBackProjection(data, trj, img_shape::NTuple{N,Int}; T = Float32, U = N==3 ? I(size(data,2)) : I(1), density_compensation=:none, verbose=false) where {N}
     Ncoef = size(U,2)
-
     p = plan_nfft(reduce(hcat, trj), img_shape; precompute=TENSOR, blocking=true, fftflags=FFTW.MEASURE)
-    xbp = Array{T}(undef, img_shape..., Ncoef, Ncoils)
 
-    data_temp = similar(@view data[:, :, 1]) # size = Ncycles*Nr x Nt
+    Ncoil = size(data[1],2)
+    xbp = Array{Complex{T}}(undef, img_shape..., Ncoef, Ncoil)
+
+    data_temp = Vector{Vector{Complex{T}}}(undef,size(data,1))
     img_idx = CartesianIndices(img_shape)
     verbose && println("calculating backprojection..."); flush(stdout)
     for icoef ∈ axes(U,2)
-        t = @elapsed for icoil ∈ axes(data, 3)
-            @simd for i ∈ CartesianIndices(data_temp)
-                @inbounds data_temp[i] = data[i,icoil] * conj(U[i[2],icoef])
+        t = @elapsed for icoil = 1:Ncoil
+            @simd for it in axes(data,1)
+                @inbounds data_temp[it] = data[it][:,icoil] * conj(U[it,icoef])
             end
             applyDensityCompensation!(data_temp, trj; density_compensation)
-            @views mul!(xbp[img_idx, icoef, icoil], adjoint(p), vec(data_temp))
+
+            @views mul!(xbp[img_idx, icoef, icoil], adjoint(p), reduce(vcat,data_temp))
         end
         verbose && println("coefficient = $icoef: t = $t s"); flush(stdout)
     end
     return xbp
 end
 
-function calculateBackProjection(data::AbstractArray{T,N}, trj, cmaps::AbstractVector{<:AbstractArray{T}}; U = N==3 ? I(size(data,2)) : I(1), density_compensation=:none, verbose=false) where {N,T}
-    if typeof(trj) <: AbstractMatrix
-        trj = [trj]
-    end
-
-    if ndims(data) == 2
-        data = reshape(data, size(data, 1), 1, size(data, 2))
-    end
-
+function calculateBackProjection(data, trj, cmaps::AbstractVector{<:AbstractArray{T}}; U = N==3 ? I(size(data,2)) : I(1), density_compensation=:none, verbose=false) where {N,T}
     test_dimension(data, trj, U, cmaps)
 
     Ncoef = size(U,2)
     img_shape = size(cmaps[1])
 
     p = plan_nfft(reduce(hcat,trj), img_shape; precompute=TENSOR, blocking = true, fftflags = FFTW.MEASURE)
+
     xbp = zeros(T, img_shape..., Ncoef)
     xtmp = Array{T}(undef, img_shape)
 
-    data_temp = similar(@view data[:,:,1]) # size = Ncycles*Nr x Nt
+    data_temp = Vector{Vector{T}}(undef,size(data,1))
     img_idx = CartesianIndices(img_shape)
     verbose && println("calculating backprojection..."); flush(stdout)
     for icoef ∈ axes(U,2)
         t = @elapsed for icoil ∈ eachindex(cmaps)
-            @simd for i ∈ CartesianIndices(data_temp)
-                @inbounds data_temp[i] = data[i,icoil] * conj(U[i[2],icoef])
+            @simd for it in axes(data,1)
+                @inbounds data_temp[it] = data[it][:,icoil] * conj(U[it,icoef])
             end
             applyDensityCompensation!(data_temp, trj; density_compensation)
 
-            mul!(xtmp, adjoint(p), vec(data_temp))
+            mul!(xtmp, adjoint(p), reduce(vcat,data_temp))
             xbp[img_idx,icoef] .+= conj.(cmaps[icoil]) .* xtmp
         end
         verbose && println("coefficient = $icoef: t = $t s"); flush(stdout)
@@ -139,15 +126,15 @@ end
 #############################################################################
 
 function applyDensityCompensation!(data, trj; density_compensation=:radial_3D)
-    for it in axes(data, 2)
+    for it in axes(data, 1)
         if density_compensation == :radial_3D
-            data[:, it] .*= transpose(sum(abs2, trj[it], dims=1))
+            data[it] .*= transpose(sum(abs2, trj[it], dims=1))
         elseif density_compensation == :radial_2D
-            data[:, it] .*= transpose(sqrt.(sum(abs2, trj[it], dims=1)))
+            data[it] .*= transpose(sqrt.(sum(abs2, trj[it], dims=1)))
         elseif density_compensation == :none
             # do nothing here
         elseif isa(density_compensation, AbstractVector{<:AbstractVector})
-            data[:, it] .*= density_compensation[it]
+            data[it] .*= density_compensation[it]
         else
             error("`density_compensation` can only be `:radial_3D`, `:radial_2D`, `:none`, or of type  `AbstractVector{<:AbstractVector}`")
         end
@@ -157,7 +144,7 @@ end
 function test_dimension(data, trj, U, cmaps)
     Nt = size(U,1)
     img_shape = size(cmaps)[1:end-1]
-    Ncoils = size(cmaps)[end]
+    Ncoil = size(cmaps)[end]
 
     Nt != size(data, 2) && ArgumentError(
         "The second dimension of data ($(size(data, 2))) and the first one of U ($Nt) do not match. Both should be number of time points.",
@@ -174,8 +161,8 @@ function test_dimension(data, trj, U, cmaps)
         "`trj` has the length $(length(trj)) and the 2ⁿᵈ dimension of data is $(size(data,2)). They should match and reflect the number of time points.",
     )
 
-    Ncoils != size(data, 3) && ArgumentError(
-        "The last dimension of `cmaps` is $(Ncoils) and the 3ⁿᵈ dimension of data is $(size(data,3)). They should match and reflect the number of coils.",
+    Ncoil != size(data, 3) && ArgumentError(
+        "The last dimension of `cmaps` is $(Ncoil) and the 3ⁿᵈ dimension of data is $(size(data,3)). They should match and reflect the number of coils.",
     )
 
 end

--- a/src/BackProjection.jl
+++ b/src/BackProjection.jl
@@ -14,7 +14,7 @@ Calculate backprojection
 - `cmaps::::AbstractVector{<:AbstractArray{T}}`: Coil sensitivities
 
 """
-function calculateBackProjection(data, trj, img_shape::NTuple{N,Int}; T = Float32, U = N==3 ? I(size(data,2)) : I(1), density_compensation=:none, verbose=false) where {N}
+function calculateBackProjection(data, trj, img_shape::NTuple{N,Int}; T = Float32, U = N==3 ? ones(size(data,1)) : I(1), density_compensation=:none, verbose=false) where {N}
     Ncoef = size(U,2)
     p = plan_nfft(reduce(hcat, trj), img_shape; precompute=TENSOR, blocking=true, fftflags=FFTW.MEASURE)
 
@@ -30,7 +30,7 @@ function calculateBackProjection(data, trj, img_shape::NTuple{N,Int}; T = Float3
                 @inbounds data_temp[it] = data[it][:,icoil] * conj(U[it,icoef])
             end
             applyDensityCompensation!(data_temp, trj; density_compensation)
-
+            
             @views mul!(xbp[img_idx, icoef, icoil], adjoint(p), reduce(vcat,data_temp))
         end
         verbose && println("coefficient = $icoef: t = $t s"); flush(stdout)
@@ -38,7 +38,7 @@ function calculateBackProjection(data, trj, img_shape::NTuple{N,Int}; T = Float3
     return xbp
 end
 
-function calculateBackProjection(data, trj, cmaps::AbstractVector{<:AbstractArray{T}}; U = N==3 ? I(size(data,2)) : I(1), density_compensation=:none, verbose=false) where {N,T}
+function calculateBackProjection(data, trj, cmaps::AbstractVector{<:AbstractArray{T}}; U = N==3 ? ones(size(data,1)) : I(1), density_compensation=:none, verbose=false) where {N,T}
     test_dimension(data, trj, U, cmaps)
 
     Ncoef = size(U,2)

--- a/src/BackProjection.jl
+++ b/src/BackProjection.jl
@@ -59,13 +59,11 @@ function calculateBackProjection(data::AbstractVector{<:AbstractMatrix{cT}}, trj
     img_shape = size(cmaps[1])
 
     p = plan_nfft(trj_v, img_shape; precompute=TENSOR, blocking = true, fftflags = FFTW.MEASURE)
-
     xbp = zeros(cT, img_shape..., Ncoef)
     xtmp = Array{cT}(undef, img_shape)
 
     trj_l = [size(trj[it],2) for it in eachindex(trj)]
     data_temp = Vector{cT}(undef,sum(trj_l))
-
     img_idx = CartesianIndices(img_shape)
     verbose && println("calculating backprojection..."); flush(stdout)
     for icoef ∈ axes(U, 2)
@@ -73,7 +71,7 @@ function calculateBackProjection(data::AbstractVector{<:AbstractMatrix{cT}}, trj
             @simd for it in eachindex(data)
                 idx1 = sum(trj_l[1:it-1]) + 1
                 idx2 = sum(trj_l[1:it])
-                @inbounds data_temp[idx1:idx2] .= data[it][:,icoil] .* conj(U[it,icoef])
+                data_temp[idx1:idx2] .= data[it][:,icoil] .* conj(U[it,icoef])
             end
             applyDensityCompensation!(data_temp, trj_v; density_compensation)
             mul!(xtmp, adjoint(p), data_temp)

--- a/src/CoilMaps.jl
+++ b/src/CoilMaps.jl
@@ -1,9 +1,9 @@
-function calcCoilMaps(data::AbstractVector{<:AbstractMatrix{Complex{T}}}, trj::AbstractVector{<:AbstractMatrix{T}}, img_shape::NTuple{N,Int}; U = N==3 ? I(size(data,2)) : I(1), density_compensation=:radial_3D, kernel_size=ntuple(_ -> 6, N), calib_size=ntuple(_ -> 24, N), eigThresh_1=0.01, eigThresh_2=0.9, nmaps=1, verbose=false) where {N,T}
+function calcCoilMaps(data::AbstractVector{<:AbstractMatrix{Complex{T}}}, trj::AbstractVector{<:AbstractMatrix{T}}, img_shape::NTuple{N,Int}; U = N==3 ? ones(size(data,1)) : I(1), density_compensation=:radial_3D, kernel_size=ntuple(_ -> 6, N), calib_size=ntuple(_ -> 24, N), eigThresh_1=0.01, eigThresh_2=0.9, nmaps=1, verbose=false) where {N,T}
     Ncoil = size(data[1], 2)
     Ndims = length(img_shape)
     imdims = ntuple(i -> i, Ndims)
 
-    xbp = calculateBackProjection(data, trj, img_shape; U=U[:,1], density_compensation, verbose)
+    xbp = calculateBackProjection(data, trj, img_shape; U=U[:,1], density_compensation, verbose) 
     xbp = dropdims(xbp, dims=ndims(xbp)-1)
 
     img_idx = CartesianIndices(img_shape)

--- a/src/CoilMaps.jl
+++ b/src/CoilMaps.jl
@@ -1,3 +1,27 @@
+"""
+    calcCoilMaps(data, trj, img_shape; U, density_compensation, kernel_size, calib_size, eigThresh_1, eigThresh_2, nmaps, verbose)
+
+Estimate coil sensitivity maps using ESPIRiT [1].
+
+# Arguments
+- `data::AbstractVector{<:AbstractMatrix{Complex{T}}}`: Complex dataset either as AbstractVector of matrices or single matrix
+- `trj::AbstractVector{<:AbstractMatrix{T}}`: Trajectory with samples corresponding to the dataset either as AbstractVector of matrices or single matrix.
+- `img_shape::NTuple{N,Int}`: Shape of image
+- `U::Matrix` = N==3 ? ones(size(data,1)) : I(1): Basis coefficients of subspace
+- `density_compensation`=:`radial_3D`: Values of `:radial_3D`, `:radial_2D`, `:none`, or of type  `AbstractVector{<:AbstractVector}`
+- `kernel_size`=`ntuple(_ -> 6, N)`: Kernel size
+- `calib_size`=`ntuple(_ -> 24, N)`: Size of calibration region
+- `eigThresh_1`=0.01: Threshold of first eigenvalue
+- `eigThresh_2`=0.9: Threshold of second eigenvalue
+- `nmaps`=1: Number of estimated maps
+- `verbose::Boolean`=`false`: Verbosity level
+
+# return
+- `cmaps::::AbstractVector{<:AbstractArray{T}}`: Coil sensitivities as AbstractVector of arrays
+
+# References
+[1] Uecker, M., Lai, P., Murphy, M.J., Virtue, P., Elad, M., Pauly, J.M., Vasanawala, S.S. and Lustig, M. (2014), ESPIRiT—an eigenvalue approach to autocalibrating parallel MRI: Where SENSE meets GRAPPA. Magn. Reson. Med., 71: 990-1001. https://doi.org/10.1002/mrm.24751
+"""
 function calcCoilMaps(data::AbstractVector{<:AbstractMatrix{Complex{T}}}, trj::AbstractVector{<:AbstractMatrix{T}}, img_shape::NTuple{N,Int}; U = N==3 ? ones(size(data,1)) : I(1), density_compensation=:radial_3D, kernel_size=ntuple(_ -> 6, N), calib_size=ntuple(_ -> 24, N), eigThresh_1=0.01, eigThresh_2=0.9, nmaps=1, verbose=false) where {N,T}
     Ncoil = size(data[1], 2)
     Ndims = length(img_shape)

--- a/src/CoilMaps.jl
+++ b/src/CoilMaps.jl
@@ -4,10 +4,12 @@
 Estimate coil sensitivity maps using ESPIRiT [1].
 
 # Arguments
-- `data::AbstractVector{<:AbstractMatrix{Complex{T}}}`: Complex dataset either as AbstractVector of matrices or single matrix
+- `data::AbstractVector{<:AbstractMatrix{Complex{T}}}`: Complex dataset either as AbstractVector of matrices or single matrix. The optional outer vector defines different time frames that are combined using the subspace defined in `U`
 - `trj::AbstractVector{<:AbstractMatrix{T}}`: Trajectory with samples corresponding to the dataset either as AbstractVector of matrices or single matrix.
 - `img_shape::NTuple{N,Int}`: Shape of image
-- `U::Matrix` = N==3 ? ones(size(data,1)) : I(1): Basis coefficients of subspace
+
+# Keyword Arguments
+- `U::Matrix` = N==3 ? ones(size(data,1)) : I(1): Basis coefficients of subspace (only defined if `data` and `trj` are vectors of matrices)
 - `density_compensation`=:`radial_3D`: Values of `:radial_3D`, `:radial_2D`, `:none`, or of type  `AbstractVector{<:AbstractVector}`
 - `kernel_size`=`ntuple(_ -> 6, N)`: Kernel size
 - `calib_size`=`ntuple(_ -> 24, N)`: Size of calibration region
@@ -17,17 +19,17 @@ Estimate coil sensitivity maps using ESPIRiT [1].
 - `verbose::Boolean`=`false`: Verbosity level
 
 # return
-- `cmaps::::AbstractVector{<:AbstractArray{T}}`: Coil sensitivities as AbstractVector of arrays
+- `cmaps::::Vector{<:Array{Complex{T}}}`: Coil sensitivities as Vector of arrays
 
 # References
 [1] Uecker, M., Lai, P., Murphy, M.J., Virtue, P., Elad, M., Pauly, J.M., Vasanawala, S.S. and Lustig, M. (2014), ESPIRiT—an eigenvalue approach to autocalibrating parallel MRI: Where SENSE meets GRAPPA. Magn. Reson. Med., 71: 990-1001. https://doi.org/10.1002/mrm.24751
 """
-function calcCoilMaps(data::AbstractVector{<:AbstractMatrix{Complex{T}}}, trj::AbstractVector{<:AbstractMatrix{T}}, img_shape::NTuple{N,Int}; U = N==3 ? ones(size(data,1)) : I(1), density_compensation=:radial_3D, kernel_size=ntuple(_ -> 6, N), calib_size=ntuple(_ -> 24, N), eigThresh_1=0.01, eigThresh_2=0.9, nmaps=1, verbose=false) where {N,T}
+function calcCoilMaps(data::AbstractVector{<:AbstractMatrix{Complex{T}}}, trj::AbstractVector{<:AbstractMatrix{T}}, img_shape::NTuple{N,Int}; U = ones(length(data)), density_compensation=:radial_3D, kernel_size=ntuple(_ -> 6, N), calib_size=ntuple(_ -> 24, N), eigThresh_1=0.01, eigThresh_2=0.9, nmaps=1, verbose=false) where {N,T}
     Ncoil = size(data[1], 2)
     Ndims = length(img_shape)
     imdims = ntuple(i -> i, Ndims)
 
-    xbp = calculateBackProjection(data, trj, img_shape; U=U[:,1], density_compensation, verbose) 
+    xbp = calculateBackProjection(data, trj, img_shape; U=U[:,1], density_compensation, verbose)
     xbp = dropdims(xbp, dims=ndims(xbp)-1)
 
     img_idx = CartesianIndices(img_shape)
@@ -45,4 +47,8 @@ function calcCoilMaps(data::AbstractVector{<:AbstractMatrix{Complex{T}}}, trj::A
 
     cmaps = [cmaps[img_idx, ic, 1] for ic = 1:Ncoil]
     return cmaps
+end
+
+function calcCoilMaps(data::AbstractMatrix{Complex{T}}, trj::AbstractMatrix{T}, img_shape::NTuple{N,Int}; density_compensation=:radial_3D, kernel_size=ntuple(_ -> 6, N), calib_size=ntuple(_ -> 24, N), eigThresh_1=0.01, eigThresh_2=0.9, nmaps=1, verbose=false) where {N,T}
+    calcCoilMaps([data], [trj], img_shape; U = I(1), density_compensation, kernel_size, calib_size, eigThresh_1, eigThresh_2, nmaps, verbose)
 end

--- a/src/CoilMaps.jl
+++ b/src/CoilMaps.jl
@@ -1,5 +1,5 @@
-function calcCoilMaps(data::AbstractArray{Complex{T},3}, trj::AbstractVector{<:AbstractMatrix{T}}, img_shape::NTuple{N,Int}; U = N==3 ? I(size(data,2)) : I(1), density_compensation=:radial_3D, kernel_size=ntuple(_ -> 6, N), calib_size=ntuple(_ -> 24, N), eigThresh_1=0.01, eigThresh_2=0.9, nmaps=1, verbose=false) where {N,T}
-    Ncoils = size(data, 3)
+function calcCoilMaps(data::AbstractVector{<:AbstractMatrix{Complex{T}}}, trj::AbstractVector{<:AbstractMatrix{T}}, img_shape::NTuple{N,Int}; U = N==3 ? I(size(data,2)) : I(1), density_compensation=:radial_3D, kernel_size=ntuple(_ -> 6, N), calib_size=ntuple(_ -> 24, N), eigThresh_1=0.01, eigThresh_2=0.9, nmaps=1, verbose=false) where {N,T}
+    Ncoil = size(data[1], 2)
     Ndims = length(img_shape)
     imdims = ntuple(i -> i, Ndims)
 
@@ -19,6 +19,6 @@ function calcCoilMaps(data::AbstractArray{Complex{T},3}, trj::AbstractVector{<:A
     end
     verbose && println("espirit: $t s")
 
-    cmaps = [cmaps[img_idx, ic, 1] for ic = 1:Ncoils]
+    cmaps = [cmaps[img_idx, ic, 1] for ic = 1:Ncoil]
     return cmaps
 end

--- a/src/FFTNormalOpBasisFunc.jl
+++ b/src/FFTNormalOpBasisFunc.jl
@@ -76,22 +76,15 @@ function calculateKernelBasis(img_shape, trj, U)
     Ncoeff = size(U, 2)
     Nt = length(trj) # number of time points
     Nrep = size(U, 1) / Nt
-
     @assert isinteger(Nrep) && (Nrep != 0) "Mismatch between trajectory and basis"
 
     Λ = zeros(eltype(U), Ncoeff, Ncoeff, img_shape...)
-
-    for it ∈ 1:size(U, 1)
-
-        t_idx = mod(it + Nt - 1, Nt) + 1 # "mod" to incorporate repeated sampling pattern, "mod(i[2]+Nt-1,Nt)+1" to compensate for one indexing
-
-        for ix ∈ axes(trj[t_idx], 2)
-
-            k_idx = ntuple(j -> mod1(Int(trj[t_idx][j, ix]) - img_shape[j] ÷ 2, img_shape[j]), length(img_shape)) # incorporates ifftshift
+    for it ∈ axes(U, 1)
+        for ix ∈ axes(trj[it], 2)
+            k_idx = ntuple(j -> mod1(Int(trj[it][j, ix]) - img_shape[j] ÷ 2, img_shape[j]), length(img_shape)) # incorporates ifftshift
             k_idx = CartesianIndex(k_idx)
-
-            for ic ∈ CartesianIndices((Ncoeff, Ncoeff))
-                Λ[ic[1], ic[2], k_idx] += conj(U[it, ic[1]]) * U[it, ic[2]]
+            for ic ∈ CartesianIndices((Ncoeff, Ncoeff)), irep ∈ axes(U, 3)
+                Λ[ic[1], ic[2], k_idx] += conj(U[it, ic[1], irep]) * U[it, ic[2], irep]
             end
         end
     end

--- a/src/FFTNormalOpBasisFunc.jl
+++ b/src/FFTNormalOpBasisFunc.jl
@@ -75,10 +75,6 @@ end
 
 function calculateKernelBasis(img_shape, trj, U)
     Ncoeff = size(U, 2)
-    Nt = length(trj) # number of time points
-    Nrep = size(U, 1) / Nt
-    @assert isinteger(Nrep) && (Nrep != 0) "Mismatch between trajectory and basis"
-
     Λ = zeros(eltype(U), Ncoeff, Ncoeff, img_shape...)
     for it ∈ axes(U, 1)
         for ix ∈ axes(trj[it], 2)

--- a/src/FFTNormalOpBasisFunc.jl
+++ b/src/FFTNormalOpBasisFunc.jl
@@ -13,10 +13,11 @@ Differentiate between functions exploiting a pre-calculated kernel basis `Λ` an
 # Arguments
 - `img_shape::Tuple{Int}`: Image dimensions
 - `traj::Vector{Matrix{Float32}}`: Trajectory
-- `U::Matrix{ComplexF32}`: Basis coefficients of subspace
+- `U::Matrix{ComplexF32}`=(1,): Basis coefficients of subspace
 - `cmaps::Matrix{ComplexF32}`: Coil sensitivities
 - `M::Vector{Matrix{Float32}}`: Mask
 - `Λ::Array{Complex{T},3}`: Toeplitz kernel basis
+-  `num_fft_threads::Int` = `round(Int, Threads.nthreads()/size(U, 2))` or `round(Int, Threads.nthreads()/size(Λ, 1)): Number of Threads for FFT
 """
 function FFTNormalOp(img_shape, trj, U; cmaps=(1,), num_fft_threads = round(Int, Threads.nthreads()/size(U, 2)))
     Λ = calculateKernelBasis(img_shape, trj, U)

--- a/src/GROG.jl
+++ b/src/GROG.jl
@@ -5,8 +5,8 @@ Perform GROG kernel calibration based on whole radial trajectory and passed data
 Calibration follows the work on self-calibrating radial GROG (https://doi.org/10.1002/mrm.21565).
 
 # Arguments
-- `data::Matrix{ComplexF32}`: Basis coefficients of subspace
-- `traj::Vector{Matrix{Float32}}`: Trajectory
+- `data::AbstractVector{<:AbstractMatrix{cT}}`: Complex dataset passed as AbstractVector of matrices
+- `trj::Vector{Matrix{Float32}}`: Trajectory with samples corresponding to the dataset passed as AbstractVector of matrices with Float32 entries
 - `Nr::Int`: Number of samples per read out
 """
 function grog_calib(data, trj, Nr)
@@ -54,19 +54,18 @@ end
 Perform gridding of data based on pre-calculated GROG kernel.
 
 # Arguments
-- `data::Matrix{ComplexF32}`: Basis coefficients of subspace
-- `traj::Vector{Matrix{Float32}}`: Trajectory
+- `data::AbstractVector{<:AbstractMatrix{cT}}`: Complex dataset passed as AbstractVector of matrices
+- `trj::Vector{Matrix{Float32}}`: Trajectory with samples corresponding to the dataset passed as AbstractVector of matrices with Float32 entries
 - `lnG::Vector{Matrix{Float32}}`: Natural logarithm of GROG kernel in all dimensions
 - `Nr::Int`: Number of samples per read out
 - `img_shape::Tuple{Int}`: Image dimensions
 
-# Dimensions:
-- `data`:   [samples, spokes, timesteps, coils, repetitions of sampling pattern]
-- `trj`:    [timesteps, repetitions][dims, samples]
-- `lnG`:    [dims][Ncoils, Ncoils]
+- `trj::Vector{Matrix{Int32}}`: Trajectory
 
-# Further:
-- Ensure sampling pattern repeats in repetitions dimension!
+# Dimensions:
+- `data`:   [timesteps][samples, spokes, coils, repetitions of sampling pattern]
+- `trj`:    [timesteps][dims, samples, repetitions]
+- `lnG`:    [dims][Ncoils, Ncoils]
 """
 function grog_gridding!(data, trj, lnG, Nr, img_shape)
 
@@ -101,13 +100,19 @@ end
 """
     radial_grog!(data, trj, Nr, img_shape)
 
-Perform GROG kernel calibration and gridding of data in-place.
+Perform GROG kernel calibration and gridding [1] of data in-place. The trajectory is returned with integer values.
 
 # Arguments
-- `data::Matrix{ComplexF32}`: Basis coefficients of subspace
-- `traj::Vector{Matrix{Float32}}`: Trajectory
+- `data::AbstractVector{<:AbstractMatrix{cT}}`: Complex dataset passed as AbstractVector of matrices
+- `trj::Vector{Matrix{Float32}}`: Trajectory with samples corresponding to the dataset passed as AbstractVector of matrices with Float32 entries
 - `Nr::Int`: Number of samples per read out
 - `img_shape::Tuple{Int}`: Image dimensions
+
+# return
+- `trj::Vector{Matrix{Int32}}`: Trajectory
+
+# References
+[1] Seiberlich, N., Breuer, F., Blaimer, M., Jakob, P. and Griswold, M. (2008), Self-calibrating GRAPPA operator gridding for radial and spiral trajectories. Magn. Reson. Med., 59: 930-935. https://doi.org/10.1002/mrm.21565
 """
 function radial_grog!(data, trj, Nr, img_shape)
     lnG = grog_calib(data, trj, Nr)

--- a/src/GROG.jl
+++ b/src/GROG.jl
@@ -11,15 +11,21 @@ Calibration follows the work on self-calibrating radial GROG (https://doi.org/10
 """
 function grog_calib(data, trj, Nr)
 
-    Ncoil = size(data, 3)
-    Nrep = size(data, 4)
+    Ncoil = size(data[1], 2)
+    Nrep = size(data[1], 3)
 
     if (1 != Nrep) # Avoid error during reshape that joins rep and t dim
-        data = permutedims(data, (1,2,4,3))
+        data = cat(data..., dims = 4)
+        data = permutedims(data, (1,4,3,2))
+    else
+        data = cat(data..., dims = 3)
+        data = permutedims(data, (1,3,2))
     end
 
     data = reshape(data, Nr, :, Ncoil)
-    Ns = size(data, 2) # number of spokes across whole trajectory
+    data = [data[:,i,:] for i=1:size(data, 2)]
+
+    Ns = length(data) # number of spokes across whole trajectory
     Nd = size(trj[1], 1) # number of dimensions
 
     Nr < Ncoil && @warn "Ncoil < Nr, problem is ill posed"
@@ -27,8 +33,8 @@ function grog_calib(data, trj, Nr)
     @assert isinteger(Ns / (Nrep * length(trj))) "Mismatch between trajectory and data"
 
     # preallocations
-    lnG = Array{eltype(data)}(undef, Nd, Ncoil, Ncoil) #matrix of GROG operators
-    vθ  = Array{eltype(data)}(undef, Ns, Ncoil, Ncoil)
+    lnG = Array{eltype(data[1])}(undef, Nd, Ncoil, Ncoil) #matrix of GROG operators
+    vθ  = Array{eltype(data[1])}(undef, Ns, Ncoil, Ncoil)
 
     # 1) Precompute n, m for the trajectory
     trjr = reshape(combinedimsview(trj), Nd, Nr, :)
@@ -36,8 +42,8 @@ function grog_calib(data, trj, Nr)
     nm = repeat(nm, outer = [Nrep]) # Stack trj in time if sampling repeats
 
     # 2) For each spoke, solve Eq3 for Gθ and compute matrix log
-    Threads.@threads for ip ∈ axes(data, 2)
-        @views Gθ = transpose(data[1:end-1, ip, :] \ data[2:end, ip, :])
+    Threads.@threads for ip ∈ axes(data, 1)
+        @views Gθ = transpose(data[ip][1:end-1, :] \ data[ip][2:end, :])
         vθ[ip, :, :] = log(Gθ) # matrix log
     end
 
@@ -73,17 +79,16 @@ Perform gridding of data based on pre-calculated GROG kernel.
 """
 function grog_gridding!(data, trj, lnG, Nr, img_shape)
 
-    Ncoil = size(data, 3)
-    Nrep = size(data, 4)
+    Ncoil = size(data[1], 2)
+    Nrep = size(data[1], 3)
 
     Nt = length(trj) # number of time points
-    data = reshape(data, :, Nt, Ncoil, Nrep) # make sure data has correct size before gridding
 
     exp_method = ExpMethodHigham2005()
     cache = [ExponentialUtilities.alloc_mem(lnG[1], exp_method) for _ ∈ 1:Threads.nthreads()]
     lGcache = [similar(lnG[1]) for _ ∈ 1:Threads.nthreads()]
 
-    Threads.@threads for i ∈ CartesianIndices(@view data[:, :, 1, 1])
+    Threads.@threads for i ∈ CartesianIndices(@view cat(data..., dims = 4)[:, 1, 1, :])
         idt = Threads.threadid() # TODO: fix data race bug
         for j ∈ eachindex(img_shape)
             trj_i = trj[i[2]][j, i[1]] * img_shape[j] + 1 / 2 # +1/2 to avoid stepping outside of FFT definition ∈ (-img_shape[j]/2+1, img_shape[j]/2)
@@ -95,7 +100,7 @@ function grog_gridding!(data, trj, lnG, Nr, img_shape)
 
             # overwrite trj with rounded grid point index.
             lGcache[idt] .= shift .* lnG[j]
-            @views data[i, :, :] =  exponential!(lGcache[idt], exp_method, cache[idt]) * data[i, :, :]
+            @views data[i[2]][i[1], :, :] =  exponential!(lGcache[idt], exp_method, cache[idt]) * data[i[2]][i[1], :, :]
         end
     end
 end

--- a/src/GROG.jl
+++ b/src/GROG.jl
@@ -91,7 +91,7 @@ function grog_gridding!(data, trj, lnG, Nr, img_shape)
 
             # overwrite trj with rounded grid point index.
             lGcache[idt] .= shift .* lnG[idim]
-            @views data[it][is, :, :] =  exponential!(lGcache[idt], exp_method, cache[idt]) * data[it][is, :, :]
+            @views data[it][is, :, :] = exponential!(lGcache[idt], exp_method, cache[idt]) * data[it][is, :, :]
         end
     end
 end

--- a/src/MRFingerprintingRecon.jl
+++ b/src/MRFingerprintingRecon.jl
@@ -10,8 +10,8 @@ using LinearOperators
 using SplitApplyCombine
 using ExponentialUtilities
 
-export FFTNormalOp, radial_grog!, calculateBackProjection_gridded
 export NFFTNormalOp, calcCoilMaps, calculateBackProjection, kooshball, kooshballGA, calcFilteredBackProjection
+export FFTNormalOp, radial_grog!
 
 function __init__()
     if Threads.nthreads() > 1

--- a/src/NFFTNormalOpBasisFunc.jl
+++ b/src/NFFTNormalOpBasisFunc.jl
@@ -11,13 +11,13 @@ Differentiate between functions exploiting a pre-calculated Toeplitz kernel basi
 
 # Arguments
 - `img_shape::Tuple{Int}`: Image dimensions
-- `traj::Vector{Matrix{Float32}}`: Trajectory
-- `U::Matrix{ComplexF32}`: Basis coefficients of subspace
-- `cmaps::Matrix{ComplexF32}`: Coil sensitivities
+- `traj::AbstractVector{<:AbstractMatrix{T}}`: Trajectory
+- `U::AbstractMatrix{Tc}`: Basis coefficients of subspace
+- `cmaps::AbstractVector{Matrix{ComplexF32}}`=`[ones(T, img_shape)]`: Coil sensitivities
 - `Λ::Array{Complex{T},3}`: Toeplitz kernel basis
 - `kmask_indcs::Vector{Int}`: Sampling indices of Toeplitz mask
-- `verbose::Boolean`: Verbose level
-- `num_fft_threads::Int`: Number of threads for FFT
+- `verbose::Boolean`=`false`: Verbose level
+- `num_fft_threads::Int`=`round(Int, Threads.nthreads()/size(U, 2))` or `round(Int, Threads.nthreads()/size(Λ, 1))`: Number of threads for FFT
 """
 function NFFTNormalOp(
     img_shape,

--- a/src/Trajectories.jl
+++ b/src/Trajectories.jl
@@ -93,13 +93,15 @@ function traj_2d_radial_goldenratio(Nr, Ncyc, Nt; thetaRot = 0, phiRot = 0, dela
 
     τ = (sqrt(5) + 1) / 2
 
-    theta = 0 * (0:(Ncyc*Nt-1)) .+ π/2 # 2D only
-    theta = reshape(theta, Nt, Ncyc)
-
-    phi = (0:(Ncyc*Nt-1)) * π / (τ + N - 1) # FIXME: Float32 results in minor differences for very long repetition trains
+    phi = (0:(Ncyc*Nt-1)) * π / (τ + N - 1)
     phi = reshape(phi, Nt, Ncyc)
 
-    return kooshball(Nr, theta', phi'; thetaRot = thetaRot, phiRot = phiRot, delay = delay)
+    theta = similar(phi)
+    theta .= π/2 # 2D
+
+    trj = kooshball(Nr, theta', phi'; thetaRot = thetaRot, phiRot = phiRot, delay = delay)
+    trj = [trj[i][1:2,:] for i ∈ eachindex(trj)] # remove 3rd dimenion
+    return trj
 end
 
 """

--- a/src/Trajectories.jl
+++ b/src/Trajectories.jl
@@ -1,5 +1,5 @@
 """
-    traj_2d_cartesian(Nx, Ny, Nz, Nt; samplingRate_units = true, T = Float32)
+    traj_cartesian(Nx, Ny, Nz, Nt; samplingRate_units = true, T = Float32)
 
 Function to calculate a 2D cartesian trajectory in units of sampling rate ∈ {x | -N/2+1 ≤ x ≤ N/2 and x ∈ Z}.
 With `samplingRate_units = false` the ouput is relative with samples ∈ [-1/2:1/2].
@@ -12,14 +12,12 @@ With `samplingRate_units = false` the ouput is relative with samples ∈ [-1/2:1
 - `samplingRate_units::Boolean`: Parameter setting the output units to sampling rate
 - `T::Type`: Type defining the output units of the trajectory
 """
-function traj_2d_cartesian(Nx, Ny, Nz, Nt; samplingRate_units = true, T = Float32)
-
+function traj_cartesian(Nx, Ny, Nz, Nt; samplingRate_units = true, T = Float32)
     kx = collect(((-Nx+1)/2:(Nx-1)/2) / (samplingRate_units ? 1 : Nx))
     ky = collect(((-Ny+1)/2:(Ny-1)/2) / (samplingRate_units ? 1 : Ny))
     kz = collect(((-Nz+1)/2:(Nz-1)/2) / (samplingRate_units ? 1 : Nz))
 
     k = Vector{Matrix{T}}(undef, Nt)
-
     for it ∈ eachindex(k)
 
         ki = Array{T,4}(undef, 3, Nx, Ny, Nz)
@@ -37,7 +35,6 @@ function traj_2d_cartesian(Nx, Ny, Nz, Nt; samplingRate_units = true, T = Float3
             k[it] = round.(k[it] .+ 0.5) # ceil operation on arrays
         end
     end
-
     return k
 end
 

--- a/src/Trajectories.jl
+++ b/src/Trajectories.jl
@@ -9,8 +9,8 @@ With `samplingRate_units = false` the ouput is relative with samples ∈ [-1/2:1
 - `Ny::Int`: Number of phase encoding lines
 - `Nz::Int`: Number of phase encoding lines (third dimension)
 - `Nt::Int`: Number of times the sampling pattern is repeated
-- `samplingRate_units::Boolean`: Parameter setting the output units to sampling rate
-- `T::Type`: Type defining the output units of the trajectory
+- `samplingRate_units::Boolean`=`true`: Parameter setting the output units to sampling rate
+- `T::Type`=`Float32`: Type defining the output units of the trajectory
 """
 function traj_cartesian(Nx, Ny, Nz, Nt; samplingRate_units = true, T = Float32)
     kx = collect(((-Nx+1)/2:(Nx-1)/2) / (samplingRate_units ? 1 : Nx))
@@ -39,7 +39,7 @@ function traj_cartesian(Nx, Ny, Nz, Nt; samplingRate_units = true, T = Float32)
 end
 
 """
-    kooshballGA(Nr, Ncyc, Nt; thetaRot = 0, phiRot = 0, delay = (0, 0, 0), T = Float32)
+    kooshballGA(Nr, Ncyc, Nt; thetaRot, phiRot, delay)
 
 Function to calculate  golden means [1] based kooshball trajectory.
 
@@ -47,10 +47,9 @@ Function to calculate  golden means [1] based kooshball trajectory.
 - `Nr::Int`: Number of read out samples
 - `Ncyc::Int`: Number of cycles
 - `Nt::Int`: Number of time steps in the trajectory
-- `thetaRot::Float`: Fixed rotation angle along theta
-- `phiRot::Float`: Fixed rotation angle along phi
-- `delay::Tuple{Float, Float, Float}`: Gradient delays in (HF, AP, LR)
-- `T::Type`: Type defining the output units of the trajectory
+- `thetaRot::Float` = 0: Fixed rotation angle along theta
+- `phiRot::Float` = 0: Fixed rotation angle along phi
+- `delay::Tuple{Float, Float, Float}`= `(0, 0, 0)`: Gradient delays in (HF, AP, LR)
 
 # References
 [1] Chan, R.W., Ramsay, E.A., Cunningham, C.H. and Plewes, D.B. (2009), Temporal stability of adaptive 3D radial MRI using multidimensional golden means. Magn. Reson. Med., 61: 354-363. https://doi.org/10.1002/mrm.21837
@@ -67,7 +66,7 @@ function kooshballGA(Nr, Ncyc, Nt; thetaRot = 0, phiRot = 0, delay = (0, 0, 0))
 end
 
 """
-    traj_2d_radial_goldenratio(Nr, Ncyc, Nt; thetaRot = 0, phiRot = 0, delay = (0, 0, 0), N = 1, T = Float32)
+    traj_2d_radial_goldenratio(Nr, Ncyc, Nt; thetaRot, phiRot, delay, N)
 
 Function to calculate 2D golden ratio based trajectory [1].
 By modifying `N` also tiny golden angles [2] are supported.
@@ -76,11 +75,10 @@ By modifying `N` also tiny golden angles [2] are supported.
 - `Nr::Int`: Number of read out samples
 - `Ncyc::Int`: Number of cycles
 - `Nt::Int`: Number of time steps in the trajectory
-- `thetaRot::Float`: Fixed rotation angle along theta
-- `phiRot::Float`: Fixed rotation angle along phi
-- `delay::Tuple{Float, Float, Float}`: Gradient delays in (HF, AP, LR)
-- `N::Int`: Number of tiny golden angle
-- `T::Type`: Type defining the output units of the trajectory
+- `thetaRot::Float` = 0: Fixed rotation angle along theta
+- `phiRot::Float` = 0: Fixed rotation angle along phi
+- `delay::Tuple{Float, Float, Float}` = `(0, 0, 0)`: Gradient delays in (HF, AP, LR)
+- `N::Int` = 1: Number of tiny golden angle
 
 # References
 [1] Winkelmann S, Schaeffter T, Koehler T, Eggers H, Doessel O. An optimal radial profile order based on the Golden Ratio for time-resolved MRI. IEEE TMI 26:68--76 (2007)
@@ -102,7 +100,7 @@ function traj_2d_radial_goldenratio(Nr, Ncyc, Nt; thetaRot = 0, phiRot = 0, dela
 end
 
 """
-    kooshball(Nr, theta, phi; thetaRot = 0, phiRot = 0, delay = (0, 0, 0))
+    kooshball(Nr, theta, phi; thetaRot, phiRot, delay)
 
 Function to calculate kooshball trajectory.
 
@@ -110,9 +108,9 @@ Function to calculate kooshball trajectory.
 - `Nr::Int`: Number of read out samples
 - `theta::Array{Float,2}`: Array with dimensions: `Ncyc, Nt` defining the angles `theta` for each cycle and timestep.
 - `phi::Array{Float,2}`: Array with dimensions: `Ncyc, Nt` defining the angles `phi` for each cycle and timestep.
-- `thetaRot::Float`: Fixed rotation angle along theta
-- `phiRot::Float`: Fixed rotation angle along phi
-- `delay::Tuple{Float, Float, Float}`: Gradient delays in (HF, AP, LR)
+- `thetaRot::Float` = 0: Fixed rotation angle along theta
+- `phiRot::Float` = 0: Fixed rotation angle along phi
+- `delay::Tuple{Float, Float, Float}` = `(0, 0, 0)`: Gradient delays in (HF, AP, LR)
 """
 function kooshball(Nr, theta, phi; thetaRot = 0, phiRot = 0, delay = (0, 0, 0))
 

--- a/test/backprojection_cart.jl
+++ b/test/backprojection_cart.jl
@@ -16,7 +16,7 @@ Nt = 1
 Ncoil = 9
 
 ## Create trajectory
-trj = MRFingerprintingRecon.traj_2d_cartesian(Nx, Nx, 1, Nt; samplingRate_units=false) # unitless for plan_nfft()
+trj = MRFingerprintingRecon.traj_cartesian(Nx, Nx, 1, Nt; samplingRate_units=false) # unitless for plan_nfft()
 trj = [trj[i][1:2,:] for i ∈ eachindex(trj)] # only 2D traj here
 
 
@@ -63,14 +63,10 @@ end
 U = ones(ComplexF32, length(data), 1)
 
 #### Convert traj to units of sampling rate
-#### Required for calculateBackProjection_gridded function
-for it ∈ eachindex(trj)
-    @views mul!(trj[it][1,:], trj[it][1,:], Nx)
-    @views mul!(trj[it][2,:], trj[it][2,:], Nx)
-    trj[it] = ceil.(Int, trj[it])
-end
+#### Required for calculateBackProjection function
+trj = [ceil.(Int32, trj_i .* Nx) for trj_i ∈ trj]
 
-reco = calculateBackProjection_gridded(data, trj, U, cmaps)
+reco = calculateBackProjection(data, trj, cmaps; U)
 reco = dropdims(reco, dims=3)
 @test abs.(x) ≈ abs.(reco) atol = 3e-5
 

--- a/test/data_removal.jl
+++ b/test/data_removal.jl
@@ -1,0 +1,126 @@
+using BenchmarkTools
+using MRFingerprintingRecon
+using ImagePhantoms
+using LinearAlgebra
+using IterativeSolvers
+using FFTW
+using NFFT
+using Test
+
+using Random
+Random.seed!(42)
+
+## set parameters
+T  = Float32
+Nx = 32
+Nc = 4
+Nt = 20
+Ncyc = 10
+
+## create test image
+x = zeros(Complex{T}, Nx, Nx, Nc)
+x[:,:,1] = transpose(shepp_logan(Nx))
+x[1:end÷2,:,1] .*= exp(1im * π/3)
+x[:,:,2] = shepp_logan(Nx)
+
+## coil maps
+Ncoil = 9
+cmaps = ones(Complex{T}, Nx, Nx, Ncoil)
+[cmaps[i,:,2] .*= exp( 1im * π * i/Nx) for i ∈ axes(cmaps,1)]
+[cmaps[i,:,3] .*= exp(-1im * π * i/Nx) for i ∈ axes(cmaps,1)]
+[cmaps[:,i,4] .*= exp( 1im * π * i/Nx) for i ∈ axes(cmaps,2)]
+[cmaps[:,i,5] .*= exp(-1im * π * i/Nx) for i ∈ axes(cmaps,2)]
+[cmaps[i,:,6] .*= exp( 2im * π * i/Nx) for i ∈ axes(cmaps,1)]
+[cmaps[i,:,7] .*= exp(-2im * π * i/Nx) for i ∈ axes(cmaps,1)]
+[cmaps[:,i,8] .*= exp( 2im * π * i/Nx) for i ∈ axes(cmaps,2)]
+[cmaps[:,i,9] .*= exp(-2im * π * i/Nx) for i ∈ axes(cmaps,2)]
+
+for i ∈ CartesianIndices(@view cmaps[:,:,1])
+    cmaps[i,:] ./= norm(cmaps[i,:])
+end
+cmaps = [cmaps[:,:,ic] for ic=1:Ncoil]
+
+
+## set up trajectory
+α_g = 2π / (1+√5)
+phi = Float32.(α_g * (1:Nt*Ncyc))
+theta = Float32.(0 * (1:Nt*Ncyc) .+ pi/2)
+phi = reshape(phi, Ncyc, Nt)
+theta = reshape(theta, Ncyc, Nt)
+
+trj = kooshball(2Nx, theta, phi)
+trj = [trj[i][1:2,:] for i ∈ eachindex(trj)]
+
+## set up basis functions
+U = randn(Complex{T}, Nt, Nc)
+U,_,_ = svd(U)
+
+## simulate data
+data = Array{Complex{T}}(undef, size(trj[1], 2), Nt, Ncoil)
+data = [data[:,it,:] for it = 1:Nt]
+
+nfftplan = plan_nfft(trj[1], (Nx,Nx))
+xcoil = copy(x)
+for icoil ∈ 1:Ncoil
+    xcoil .= x
+    xcoil .*= cmaps[icoil]
+    for it ∈ axes(data,1)
+        nodes!(nfftplan, trj[it])
+        xt = reshape(reshape(xcoil, :, Nc) * U[it,:], Nx, Nx)
+        @views mul!(data[it][:,icoil], nfftplan, xt)
+    end
+end
+
+# create mask with false value to remove
+it_rm = 1
+icyc_rm = 5
+maskDataSelection = trues(2Nx, Ncyc, Nt)
+maskDataSelection[:, icyc_rm, it_rm] .= false
+
+maskDataSelection = reshape(maskDataSelection,:,Nt)
+maskDataSelection = [vec(maskDataSelection[:,i]) for i in axes(maskDataSelection,2)]
+
+# remove data
+for it ∈ 1:Nt
+    data[it] = data[it][maskDataSelection[it],:] 
+    trj[it] = trj[it][:,maskDataSelection[it]] 
+end
+
+## Test BackProjection 
+img_shape = (Nx,Nx)
+b_temp = calculateBackProjection(data, trj, img_shape)
+
+b = calculateBackProjection(data, trj, cmaps; U=U)
+
+## construct forward operator
+A = NFFTNormalOp((Nx,Nx), trj, U, cmaps=cmaps)
+
+## test forward operator
+λ = zeros(Complex{T}, Nc, Nc, 2Nx*2Nx)
+for i ∈ eachindex(A.prod!.A.kmask_indcs)
+    λ[:,:,A.prod!.A.kmask_indcs[i]] .= A.prod!.A.Λ[:,:,i]
+end
+λ = reshape(λ, Nc, Nc, 2Nx, 2Nx)
+
+for i = 1:Nc, j = 1:Nc
+    l1 = conj.(λ[i,j,:,:])
+    l2 = λ[j,i,:,:]
+    l2 = conj.(fft(conj.(ifft(l2))))
+    @test l1 ≈ l2 rtol = 1e-4
+end
+
+## reconstruct
+xr = cg(A, vec(b), maxiter=20)
+xr = reshape(xr, Nx, Nx, Nc)
+
+## crop x
+xc = fftshift(fft(x, 1:2), 1:2)
+for i ∈ CartesianIndices(xc)
+    if (i[1] - Nx/2)^2 + (i[2] - Nx/2)^2 > (Nx/2)^2
+        xc[i] = 0
+    end
+end
+xc = ifft(ifftshift(xc, 1:2), 1:2)
+
+##
+@test xr ≈ xc rtol = 1e-1

--- a/test/grog_grid_backproj.jl
+++ b/test/grog_grid_backproj.jl
@@ -64,8 +64,11 @@ for icoil ∈ 1:Ncoil
     end
 end
 
+## Move data to vector format
+data = [data[:,i,:] for i=1:size(data,2)]
+
 ## Reconstruction and test
-U = ones(ComplexF32, size(data)[2], 1)
+U = ones(ComplexF32, length(data), 1)
 
 #### Convert traj to units of sampling rate
 #### Required for calculateBackProjection_gridded function

--- a/test/grog_precalc_shift.jl
+++ b/test/grog_precalc_shift.jl
@@ -20,7 +20,6 @@ Ncyc = 3
 
 ## Create trajectory
 trj = MRFingerprintingRecon.traj_2d_radial_goldenratio(Nr, Ncyc, Nt; N=1)
-trj = [trj[i][1:Nd,:] for i ∈ eachindex(trj)] # only 2D traj, here
 
 ## Create phantom geometry
 x = shepp_logan(Nx)

--- a/test/grog_precalc_shift.jl
+++ b/test/grog_precalc_shift.jl
@@ -71,13 +71,13 @@ lnG2 = MRFingerprintingRecon.grog_calib(data2, trj, Nr)
 ## #####################################
 # Test Gridding with GROG kernel
 ########################################
-trj1 =  deepcopy(trj)
+trj2 =  deepcopy(trj)
 
 # Gridding of each sample with non repeating trajectory (Reference)
-MRFingerprintingRecon.grog_gridding!(data, trj1, lnG, Nr, (Nx,Nx))
+trj = MRFingerprintingRecon.grog_gridding!(data, trj, lnG, Nr, (Nx,Nx))
 
 # Exploit Precalculated Shifts
-MRFingerprintingRecon.grog_gridding!(data2, trj, lnG2, Nr, (Nx,Nx))
+trj2 = MRFingerprintingRecon.grog_gridding!(data2, trj2, lnG2, Nr, (Nx,Nx))
 
 # Compare gridding with and without repeating pattern
 @test data[1] ≈ data2[1][:,:,1] rtol = 1e-6
@@ -87,19 +87,18 @@ MRFingerprintingRecon.grog_gridding!(data2, trj, lnG2, Nr, (Nx,Nx))
 ## #####################################
 # Test Gridded Reconstruction with and without Repeating Pattern
 ########################################
-
 U = ones(ComplexF32, length(data), 1)
 
 # Reconstruction without repeating pattern
 A_grog = FFTNormalOp((Nx,Nx), trj, U; cmaps)
-x1 = calculateBackProjection_gridded(data, trj, U, cmaps)
+x1 = calculateBackProjection(data, trj, cmaps; U)
 xg1 = cg(A_grog, vec(x1), maxiter=20)
 xg1 = reshape(xg1, Nx, Nx)
 
 # Reconstruction with repeating pattern
 U2 = repeat(U, 1, 1, Nrep) # For joint subspace reconstruction
-A_grog = FFTNormalOp((Nx,Nx), trj, U2; cmaps)
-x2 = calculateBackProjection_gridded(data2, trj, U2, cmaps)
+A_grog = FFTNormalOp((Nx,Nx), trj2, U2; cmaps)
+x2 = calculateBackProjection(data2, trj2, cmaps; U=U2)
 xg2 = cg(A_grog, vec(x2), maxiter=20)
 xg2 = reshape(xg2, Nx, Nx)
 

--- a/test/grog_precalc_shift.jl
+++ b/test/grog_precalc_shift.jl
@@ -98,7 +98,7 @@ xg1 = cg(A_grog, vec(x1), maxiter=20)
 xg1 = reshape(xg1, Nx, Nx)
 
 # Reconstruction with repeating pattern
-U2 = repeat(U, outer=[Nrep]) # For joint subspace reconstruction
+U2 = repeat(U, 1, 1, Nrep) # For joint subspace reconstruction
 A_grog = FFTNormalOp((Nx,Nx), trj, U2; cmaps)
 x2 = calculateBackProjection_gridded(data2, trj, U2, cmaps)
 xg2 = cg(A_grog, vec(x2), maxiter=20)

--- a/test/grog_precalc_shift.jl
+++ b/test/grog_precalc_shift.jl
@@ -59,6 +59,9 @@ end
 # Create repeating pattern
 data2 = repeat(deepcopy(data), outer = [1, 1, 1, Nrep])
 
+## Vectorize data
+data = [data[:,i,:,:] for i=1:size(data,2)]
+data2 = [data2[:,i,:,:] for i=1:size(data2,2)]
 
 ## #####################################
 # Test Calibration of GROG kernel
@@ -82,15 +85,15 @@ MRFingerprintingRecon.grog_gridding!(data, trj1, lnG, Nr, (Nx,Nx))
 MRFingerprintingRecon.grog_gridding!(data2, trj, lnG2, Nr, (Nx,Nx))
 
 # Compare gridding with and without repeating pattern
-@test data ≈ data2[:,:,:,1] rtol = 1e-6
-@test data ≈ data2[:,:,:,3] rtol = 1e-6
+@test data[1] ≈ data2[1][:,:,1] rtol = 1e-6
+@test data[1] ≈ data2[1][:,:,3] rtol = 1e-6
 
 
 ## #####################################
 # Test Gridded Reconstruction with and without Repeating Pattern
 ########################################
 
-U = ones(ComplexF32, size(data)[2], 1)
+U = ones(ComplexF32, length(data), 1)
 
 # Reconstruction without repeating pattern
 A_grog = FFTNormalOp((Nx,Nx), trj, U; cmaps)

--- a/test/grog_recon.jl
+++ b/test/grog_recon.jl
@@ -35,15 +35,6 @@ cmaps[:,:,7] .= phantom(1:Nx, 1:Nx, [gauss2((7Nx÷8, Nx÷8),  (Nx÷1.5,Nx÷1.5))
 cmaps[:,:,8] .= phantom(1:Nx, 1:Nx, [gauss2((7Nx÷8, Nx÷2),  (Nx÷1.5,Nx÷1.5))], 2)
 cmaps[:,:,9] .= phantom(1:Nx, 1:Nx, [gauss2((7Nx÷8, 7Nx÷8), (Nx÷1.5,Nx÷1.5))], 2)
 
-# [cmaps[i,:,2] .*= exp( 1im * π/4 * i/Nx) for i ∈ axes(cmaps,1)]
-# [cmaps[i,:,3] .*= exp(-1im * π/4 * i/Nx) for i ∈ axes(cmaps,1)]
-# [cmaps[:,i,4] .*= exp( 1im * π/4 * i/Nx) for i ∈ axes(cmaps,2)]
-# [cmaps[:,i,5] .*= exp(-1im * π/4 * i/Nx) for i ∈ axes(cmaps,2)]
-# [cmaps[i,:,6] .*= exp( 2im * π/4 * i/Nx) for i ∈ axes(cmaps,1)]
-# [cmaps[i,:,7] .*= exp(-2im * π/4 * i/Nx) for i ∈ axes(cmaps,1)]
-# [cmaps[:,i,8] .*= exp( 2im * π/4 * i/Nx) for i ∈ axes(cmaps,2)]
-# [cmaps[:,i,9] .*= exp(-2im * π/4 * i/Nx) for i ∈ axes(cmaps,2)]
-
 for i ∈ CartesianIndices(@view cmaps[:,:,1])
     cmaps[i,:] ./= norm(cmaps[i,:])
 end
@@ -86,11 +77,15 @@ for i ∈ CartesianIndices(xc)
 end
 xc = ifft(ifftshift(xc, 1:2), 1:2)
 
+## Move data to vector format
+data = [data[:,i,:] for i=1:size(data,2)]
+
 ## NFFT Reconstruction
 xbp_rad = calculateBackProjection(data, trj, cmaps; U=U)
 A_rad = NFFTNormalOp((Nx,Nx), trj, U; cmaps=cmaps)
 xr = cg(A_rad, vec(xbp_rad), maxiter=20)
 xr = reshape(xr, Nx, Nx, Nc)
+
 
 ## GROG Reconstruction
 radial_grog!(data, trj, Nr, (Nx,Nx))

--- a/test/grog_recon.jl
+++ b/test/grog_recon.jl
@@ -89,8 +89,8 @@ xr = reshape(xr, Nx, Nx, Nc)
 
 
 ## GROG Reconstruction
-radial_grog!(data, trj, Nr, (Nx,Nx))
-xbp_grog = calculateBackProjection_gridded(data, trj, U, cmaps)
+trj = radial_grog!(data, trj, Nr, (Nx,Nx))
+xbp_grog = calculateBackProjection(data, trj, cmaps; U)
 A_grog = FFTNormalOp((Nx,Nx), trj, U; cmaps)
 xg = cg(A_grog, vec(xbp_grog), maxiter=20)
 xg = reshape(xg, Nx, Nx, Nc)

--- a/test/grog_recon.jl
+++ b/test/grog_recon.jl
@@ -77,6 +77,10 @@ for i ∈ CartesianIndices(xc)
 end
 xc = ifft(ifftshift(xc, 1:2), 1:2)
 
+## Remove some data
+data[2] = data[2][1:end-Nr,:]
+trj[2]  =  trj[2][:,1:end-Nr]
+
 ## NFFT Reconstruction
 xbp_rad = calculateBackProjection(data, trj, cmaps; U=U)
 A_rad = NFFTNormalOp((Nx,Nx), trj, U; cmaps=cmaps)

--- a/test/grog_spoke_shift.jl
+++ b/test/grog_spoke_shift.jl
@@ -20,7 +20,6 @@ Ncoil = 9
 
 ## Create trajectory
 trj = MRFingerprintingRecon.traj_2d_radial_goldenratio(Nr, 1, Nt; N=1)
-trj = [trj[i][1:2,:] for i ∈ eachindex(trj)] # only 2D traj, here
 
 ## Create phantom geometry
 x = shepp_logan(Nx)

--- a/test/grog_spoke_shift.jl
+++ b/test/grog_spoke_shift.jl
@@ -15,11 +15,11 @@ Random.seed!(42)
 T  = Float32
 Nx = 32
 Nr = 2Nx
-Nt = 100
+Nspokes = 100
 Ncoil = 9
 
 ## Create trajectory
-trj = MRFingerprintingRecon.traj_2d_radial_goldenratio(Nr, 1, Nt; N=1)
+trj = MRFingerprintingRecon.traj_2d_radial_goldenratio(Nr, Nspokes, 1; N=1)
 
 ## Create phantom geometry
 x = shepp_logan(Nx)
@@ -45,35 +45,29 @@ cmaps = [cmaps[:,:,ic] for ic=1:Ncoil]
 
 
 ## Simulate data
-data = Array{Complex{T}}(undef, size(trj[1], 2), Nt, Ncoil)
+data = [Matrix{Complex{T}}(undef, size(trj[1], 2), Ncoil)]
 nfftplan = plan_nfft(trj[1], (Nx,Nx))
 xcoil = copy(x)
 for icoil ∈ 1:Ncoil
     xcoil .= x
     xcoil .*= cmaps[icoil]
-    for it ∈ axes(data,2)
+    for it ∈ eachindex(data)
         nodes!(nfftplan, trj[it])
-        @views mul!(data[:,it,icoil], nfftplan, xcoil)
+        @views mul!(data[it][:,icoil], nfftplan, xcoil)
     end
 end
 
-# Rearrange data into vector
-data = [data[:,i,:] for i=1:size(data,2)]
 
 ## Test GROG kernels for some spokes in golden ratio based trajectory
-
 lnG = MRFingerprintingRecon.grog_calib(data, trj, Nr)
 
-for ispoke ∈ rand(axes(data, 1), 42) # test randomly 42 spokes
-
+data_r = reshape(data[1], Nr, Nspokes, Ncoil)
+trj_r = reshape(trj[1], 2, Nr, Nspokes)
+for ispoke ∈ rand(axes(trj_r, 3), 42) # test randomly 42 time frames
     # Distance matrix θn
-    nm = dropdims(diff(trj[ispoke][:,1:2],dims=2),dims=2) .* Nr
-
-    # d1 = [data[j,ispoke,:][ic] for j in 1:Nr-1, ic = 1:Ncoil]
-
-    d1_shifted = [(exp(nm[1] * lnG[1]) * exp(nm[2] * lnG[2]) * data[ispoke][j,:])[ic] for j in 1:Nr-1, ic =1:Ncoil]
-
-    d2 = [data[ispoke][j,:][ic] for j in 2:Nr, ic = 1:Ncoil]
+    nm = dropdims(diff(trj_r[:, 1:2, ispoke],dims=2),dims=2) .* Nr
+    d1_shifted = [(exp(nm[1] * lnG[1]) * exp(nm[2] * lnG[2]) * data_r[j, ispoke, :])[ic] for j in 1:Nr-1, ic =1:Ncoil]
+    d2 = [data_r[j, ispoke, :][ic] for j in 2:Nr, ic = 1:Ncoil]
 
     # FIXME: Relative tolerance the best choice?
     @test d1_shifted ≈ d2 rtol = 3e-1

--- a/test/grog_spoke_shift.jl
+++ b/test/grog_spoke_shift.jl
@@ -24,7 +24,6 @@ trj = [trj[i][1:2,:] for i ∈ eachindex(trj)] # only 2D traj, here
 
 ## Create phantom geometry
 x = shepp_logan(Nx)
-# heatmap(abs.(x), clim=(0.85, 1.25))
 
 
 ## Simulate coil sensitivity maps
@@ -59,25 +58,23 @@ for icoil ∈ 1:Ncoil
     end
 end
 
+# Rearrange data into vector
+data = [data[:,i,:] for i=1:size(data,2)]
 
 ## Test GROG kernels for some spokes in golden ratio based trajectory
 
 lnG = MRFingerprintingRecon.grog_calib(data, trj, Nr)
 
-data_r = reshape(data, Nr, :, Ncoil)
-
-trj_r = reshape(combinedimsview(trj), 2, Nr, :)
-
-for ispoke ∈ rand(axes(data_r, 2), 42) # test randomly 42 spokes
+for ispoke ∈ rand(axes(data, 1), 42) # test randomly 42 spokes
 
     # Distance matrix θn
-    nm = dropdims(diff(trj_r[:,1:2,ispoke],dims=2),dims=2) .* Nr
+    nm = dropdims(diff(trj[ispoke][:,1:2],dims=2),dims=2) .* Nr
 
-    # d1 = [data_r[j,ispoke,:][ic] for j in 1:Nr-1, ic = 1:Ncoil]
+    # d1 = [data[j,ispoke,:][ic] for j in 1:Nr-1, ic = 1:Ncoil]
 
-    d1_shifted = [(exp(nm[1] * lnG[1]) * exp(nm[2] * lnG[2]) * data_r[j,ispoke,:])[ic] for j in 1:Nr-1, ic =1:Ncoil]
+    d1_shifted = [(exp(nm[1] * lnG[1]) * exp(nm[2] * lnG[2]) * data[ispoke][j,:])[ic] for j in 1:Nr-1, ic =1:Ncoil]
 
-    d2 = [data_r[j,ispoke,:][ic] for j in 2:Nr, ic = 1:Ncoil]
+    d2 = [data[ispoke][j,:][ic] for j in 2:Nr, ic = 1:Ncoil]
 
     # FIXME: Relative tolerance the best choice?
     @test d1_shifted ≈ d2 rtol = 3e-1

--- a/test/reconstruct_radial.jl
+++ b/test/reconstruct_radial.jl
@@ -69,6 +69,9 @@ for icoil ∈ 1:Ncoil
     end
 end
 
+## Move data to vector format
+data = [data[:,i,:] for i=1:size(data,2)]
+
 ## BackProjection
 b = calculateBackProjection(data, trj, cmaps; U=U)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using Test
 end
 
 @testset "Recon Cartesian" begin
+    include("backprojection_cart.jl")
     include("reconstruct_cart.jl")
 end
 
@@ -19,7 +20,6 @@ end
 
 @testset "GROG" begin
     include("grog_spoke_shift.jl")
-    include("grog_grid_backproj.jl")
     include("grog_precalc_shift.jl")
     include("grog_recon.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,13 @@ using Test
 @testset "Recon Radial" begin
     include("reconstruct_radial.jl")
 end
+
 @testset "Recon Cartesian" begin
     include("reconstruct_cart.jl")
+end
+
+@testset "Recon data removal" begin
+    include("data_removal.jl")
 end
 
 @testset "GROG" begin


### PR DESCRIPTION
Changed format of data from array to vector. Most changes are in calculateBackProjection, which now works using a long vector of size Nt*Nr*30 and moves along the vector by "shifting" indices. Other minor changes to other functions in BackProjection. Only minor changes to CoilMaps.