### PR TITLE
Cartesian coilmaps

### DIFF
--- a/src/BackProjection.jl
+++ b/src/BackProjection.jl
@@ -91,7 +91,7 @@ function calculateBackProjection(data::AbstractArray{cT}, trj::AbstractMatrix{T}
 end
 
 # Method for GROG gridded data / trajectory
-function calculateBackProjection(data::AbstractVector{<:AbstractArray}, trj::AbstractVector{<:AbstractMatrix{<:Integer}}, cmaps::AbstractVector{<:AbstractArray{cT,N}}; U=I(length(data))) where {cT<:Complex, N}
+function calculateBackProjection(data::AbstractVector{<:AbstractArray}, trj::AbstractVector{<:AbstractMatrix{<:Integer}}, cmaps::AbstractVector{<:AbstractArray}; U=I(length(data)))
     Ncoeff = size(U, 2)
     img_shape = size(cmaps[1])
     img_idx = CartesianIndices(img_shape)

--- a/src/CoilMaps.jl
+++ b/src/CoilMaps.jl
@@ -1,7 +1,7 @@
 """
     calcCoilMaps(data, trj, img_shape; U, density_compensation, kernel_size, calib_size, eigThresh_1, eigThresh_2, nmaps, verbose)
 
-Estimate coil sensitivity maps using ESPIRiT [1]. 
+Estimate coil sensitivity maps using ESPIRiT [1].
 
 # Arguments
 - `data::AbstractVector{<:AbstractMatrix{Complex{T}}}`: Complex dataset either as AbstractVector of matrices or single matrix. The optional outer vector defines different time frames that are combined using the subspace defined in `U`


### PR DESCRIPTION
Added methods to estimate coil sensitivity profiles from Cartesian data. Similar to the existing backprojection and kernel calculations, the Cartesian methods are used if eltype(trj) <: Int.