### PR TITLE
Fixed bug in the Cartesian version of calcCoilMaps.

### DIFF
--- a/src/CoilMaps.jl
+++ b/src/CoilMaps.jl
@@ -60,9 +60,8 @@ function calcCoilMaps(data::AbstractVector{<:AbstractMatrix{Complex{T}}}, trj::A
     imdims = ntuple(i -> i, Ndims)
     Nt = length(trj)
 
-    # Normalized trajectory to obtain trj_idx within calibration region
-    trj_norm = [trj[it] ./ img_shape for it ∈ 1:Nt]
-
+    # Adjusted trajectory to obtain trj_idx within calibration region
+    trj_norm = [(trj[it] .- 1) ./ img_shape .- 0.5 for it ∈ 1:Nt]
     calib_scale = img_shape ./ calib_size
 
     trj_calib = Vector{Matrix{Integer}}(undef, Nt)


### PR DESCRIPTION
Fixed an error I made yesterday by assuming that the Cartesian trajectory in the package is defined from -N/2, ..., N/2-1; while it's actually 1, ..., N. 

Change is needed to correct phase errors in the images. Unfortunately, this did not matter for the Bruker reconstructions. 